### PR TITLE
Prefer `glue_data()` when data might be list-ish, not an actual environment

### DIFF
--- a/R/load_opts.R
+++ b/R/load_opts.R
@@ -136,8 +136,8 @@ parse_opts <- function(lst, envir){
       # whisker is not updating, and has issues with . in names
       # https://github.com/edwindj/whisker/issues/18
       # https://github.com/edwindj/whisker/issues/24
-      lst[[i]] = glue::glue(lst[[i]], .envir = lst, .open = "{{{", .close = "}}}")
-      # lst[[i]] = glue::glue_data(.x = lst, ... = lst[[i]], .open = "{{{", .close = "}}}")
+      #lst[[i]] = glue::glue(lst[[i]], .envir = lst, .open = "{{{", .close = "}}}")
+      lst[[i]] = glue::glue_data(.x = lst, lst[[i]], .open = "{{{", .close = "}}}")
     }
   }
   return(lst)

--- a/R/load_opts.R
+++ b/R/load_opts.R
@@ -26,7 +26,7 @@
     message("Configuration file does not exist, loading skipped. Expecting a file at:", x)
     return()
   }
-  conf <- try(read_sheet(x, allowEscape = TRUE, header = FALSE, verbose = verbose))
+  conf <- try(read_sheet(x, allowEscapes = TRUE, header = FALSE, verbose = verbose))
   if(class(conf) == "try-error")
     stop("error in read_sheet \nThere was a problem reading this file: ", x, "\nMake sure that all lines are two columns ",
          "separated by TAB. ")


### PR DESCRIPTION
This PR is inspired by doing revdep checks for glue. I'm going to temporarily back off on the associated change in glue, just so I can release without any breakage of other packages.

But please do consider this a heads up that, in the future, `glue::glue()` will error when `.envir` is not an actual environment. `.envir` has always been documented to be an environment and I'd like to make that actually true.

OTOH `glue_data()` *does* officially accept something "list-ish" as `.x`. So I think it's a better choice for your usage.

Backstory in glue:

https://github.com/tidyverse/glue/issues/308
https://github.com/tidyverse/glue/commit/e2b74ff17704261b5a7da25b4ebd2dec94740764